### PR TITLE
Adjust verbose output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,29 +25,31 @@ Run in verbose mode:
 ```bash
 $ echo '60016000526001601ff3' | xxd -r -p | zig build run -- -v
 PUSH1 0x01
-  Stack: push 0x01
+  Stack: push 0x1
 ---
 PUSH1 0x00
-  Stack: push 0x00
+  Stack: push 0x0
 ---
-  Stack: pop 0x00
-  Stack: pop 0x01
-MSTORE offset=0, value=1
+MSTORE
+  Stack: pop 0x0
+  Stack: pop 0x1
+  Memory: Writing value=0x1 to memory offset=0
   Memory: 0x00000000000000000000000000000001
 ---
 PUSH1 0x01
-  Stack: push 0x01
+  Stack: push 0x1
 ---
 PUSH1 0x1f
   Stack: push 0x1f
 ---
+RETURN
   Stack: pop 0x1f
-  Stack: pop 0x01
-RETURN offset=31, size=1
+  Stack: pop 0x1
+  Memory: reading size=1 bytes from offset=31
   Return value: 0x01
 ---
 EVM gas used:    18
-execution time:  830.530µs
+execution time:  700.022µs
 0x01
 ```
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -72,11 +72,12 @@ const VM = struct {
                 return true;
             },
             OpCode.MSTORE => {
+                self.printVerbose("{s}\n", .{@tagName(op)});
                 const offset = self.stack.pop();
                 self.printVerbose("  Stack: pop 0x{x}\n", .{offset});
                 const value = self.stack.pop();
                 self.printVerbose("  Stack: pop 0x{x}\n", .{value});
-                self.printVerbose("{s} offset={d}, value=0x{x}\n", .{ @tagName(op), offset, value });
+                self.printVerbose("  Memory: Writing value=0x{x} to memory offset={d}\n", .{ value, offset });
                 if (offset != 0) {
                     return VMError.NotImplemented;
                 }
@@ -90,14 +91,16 @@ const VM = struct {
                 return true;
             },
             OpCode.RETURN => {
+                self.printVerbose("{s}\n", .{@tagName(op)});
                 const offset256 = self.stack.pop();
                 self.printVerbose("  Stack: pop 0x{x}\n", .{offset256});
                 const size256 = self.stack.pop();
                 self.printVerbose("  Stack: pop 0x{x}\n", .{size256});
-                self.printVerbose("{s} offset={d}, size={d}\n", .{ @tagName(op), offset256, size256 });
 
                 const offset = std.math.cast(u32, offset256) orelse return VMError.MemoryReferenceTooLarge;
                 const size = std.math.cast(u32, size256) orelse return VMError.MemoryReferenceTooLarge;
+
+                self.printVerbose("  Memory: reading size={d} bytes from offset={d}\n", .{ size, offset });
 
                 self.returnValue = try readMemory(self.allocator, self.memory.items, offset, size);
                 self.printVerbose("  Return value: 0x{}\n", .{std.fmt.fmtSliceHexLower(self.returnValue)});


### PR DESCRIPTION
Always print the raw opcodes first and then follow with the more detailed events indented