### PR TITLE
Use a buffered reader

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -7,7 +7,8 @@ pub fn main() !void {
     const allocator = gpa.allocator();
     defer _ = gpa.deinit();
 
-    var reader = std.io.getStdIn().reader();
+    const in = std.io.getStdIn();
+    var reader = std.io.bufferedReader(in.reader());
 
     var evm = vm.VM{};
     evm.init(allocator);

--- a/src/main.zig
+++ b/src/main.zig
@@ -8,7 +8,9 @@ pub fn main() !void {
     defer _ = gpa.deinit();
 
     const in = std.io.getStdIn();
-    var reader = std.io.bufferedReader(in.reader());
+    var buf = std.io.bufferedReader(in.reader());
+
+    var reader = buf.reader();
 
     var evm = vm.VM{};
     evm.init(allocator);

--- a/src/main.zig
+++ b/src/main.zig
@@ -9,7 +9,6 @@ pub fn main() !void {
 
     const in = std.io.getStdIn();
     var buf = std.io.bufferedReader(in.reader());
-
     var reader = buf.reader();
 
     var evm = vm.VM{};


### PR DESCRIPTION
Without a buffered reader, we're doing a syscall for every call to `readByte`, so we should use a buffered reader.