### PR TITLE
Fix benchmarks by avoiding block on xxd

### DIFF
--- a/dev-scripts/benchmark-single-input
+++ b/dev-scripts/benchmark-single-input
@@ -12,14 +12,22 @@ set -o pipefail
 readonly VM_BINARY="$1"
 readonly INPUT_FILE="$2"
 
-readonly OUTPUT_FILE="$(mktemp)"
+OUTPUT_FILE="$(mktemp)"
+readonly OUTPUT_FILE
 
 if [[ $(basename $VM_BINARY) == *evm ]]; then
   "${VM_BINARY}" run --codefile "${INPUT_FILE}" --statdump \
     > /dev/null \
     2> "${OUTPUT_FILE}"
 else
-  xxd -r -p < "${INPUT_FILE}" | "$VM_BINARY" > "${OUTPUT_FILE}"
+  INPUT_FILE_BINARY="$(mktemp)"
+  readonly INPUT_FILE_BINARY
+
+  # We can't pipeline directly from xxd into the binary, as it throws off our
+  # measurements.
+  # https://ziggit.dev/t/zig-build-run-is-10x-faster-than-compiled-binary/3446?u=mtlynch
+  xxd -r -p < "${INPUT_FILE}" > "${INPUT_FILE_BINARY}
+  "$VM_BINARY" < "${INPUT_FILE_BINARY}" > "${OUTPUT_FILE}"
 fi
 
 grep -oP 'execution time:\s+\K\d+\.\d+' "${OUTPUT_FILE}"

--- a/dev-scripts/benchmark-single-input
+++ b/dev-scripts/benchmark-single-input
@@ -26,7 +26,7 @@ else
   # We can't pipeline directly from xxd into the binary, as it throws off our
   # measurements.
   # https://ziggit.dev/t/zig-build-run-is-10x-faster-than-compiled-binary/3446?u=mtlynch
-  xxd -r -p < "${INPUT_FILE}" > "${INPUT_FILE_BINARY}
+  xxd -r -p < "${INPUT_FILE}" > "${INPUT_FILE_BINARY}"
   "$VM_BINARY" < "${INPUT_FILE_BINARY}" > "${OUTPUT_FILE}"
 fi
 


### PR DESCRIPTION
If we pipeline xxd's output into eth-zvm, then eth-zvm ends up waiting on xxd to finish before it can begin processing input. Instead, we run xxd as a separate step and write its output to a file that eth-zvm can read directly.