### PR TITLE
Simplify max performance example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ For now, this is a just-for-fun experiment to learn more about Zig and Ethereum.
 Run with maximum performance:
 
 ```bash
-$ INFILE="$(mktemp)" && \
-    echo '60016000526001601ff3' | xxd -r -p > "${INFILE}" && \
-    zig build run -Doptimize=ReleaseFast < "${INFILE}"
+$ echo '60016000526001601ff3' | xxd -r -p | zig build run -Doptimize=ReleaseFast
 EVM gas used:    18
 execution time:  56.443µs
 0x01


### PR DESCRIPTION
Now that we read everything into memory up front (#34), we don't have to be so careful about pipeline measurements.